### PR TITLE
fixed ES2+ compatibility in transport address regex.

### DIFF
--- a/aioes/transport.py
+++ b/aioes/transport.py
@@ -25,7 +25,7 @@ class Transport:
     """
 
     # get ip/port from "inet[wind/127.0.0.1:9200]"
-    ADDRESS_RE = re.compile(r'/(?P<host>[\.:0-9a-f]*):(?P<port>[0-9]+)\]?$')
+    ADDRESS_RE = re.compile(r'(?:^|/)(?P<host>[\.:0-9a-f]*):(?P<port>[0-9]+)\]?$')
 
     def __init__(self, endpoints, *,
                  sniffer_interval=None, sniffer_timeout=0.1, max_retries=3,

--- a/aioes/transport.py
+++ b/aioes/transport.py
@@ -24,8 +24,9 @@ class Transport:
 
     """
 
-    # get ip/port from "inet[wind/127.0.0.1:9200]"
-    ADDRESS_RE = re.compile(r'(?:^|/)(?P<host>[\.:0-9a-f]*):(?P<port>[0-9]+)\]?$')
+    # get ip/port from "inet[wind/127.0.0.1:9200]" or "127.0.0.1:9200"
+    ADDRESS_RE = re.compile(
+            r'(?:^|/)(?P<host>[\.:0-9a-f]*):(?P<port>[0-9]+)\]?$')
 
     def __init__(self, endpoints, *,
                  sniffer_interval=None, sniffer_timeout=0.1, max_retries=3,


### PR DESCRIPTION
elasticsearch 2+ http API (nodes/_all/clear) does not reply with inet[/ip:port] but plain ip:port.

the regex now matches "ip:port" and "inet[/ip:port]"