### PR TITLE
Allow scheme, username and password in connections

### DIFF
--- a/aioes/connection.py
+++ b/aioes/connection.py
@@ -21,7 +21,7 @@ class Connection:
         self._session = aiohttp.ClientSession(
             connector=aiohttp.TCPConnector(use_dns_cache=True, loop=loop),
             loop=loop)
-        self._base_url = 'http://{0.host}:{0.port}/'.format(endpoint)
+        self._base_url = '{0.scheme}://{0.host}:{0.port}/'.format(endpoint)
 
     @property
     def endpoint(self):

--- a/aioes/pool.py
+++ b/aioes/pool.py
@@ -132,7 +132,7 @@ class ConnectionPool:
         no connections are availible and passes the list of live connections to
         the selector instance to choose from.
 
-        Returns a connection instance and it's current fail count.
+        Returns a connection instance
         """
         yield from self.resurrect()
 

--- a/aioes/transport.py
+++ b/aioes/transport.py
@@ -20,7 +20,7 @@ def validate_endpoint(endpoint):
     if endpoint.scheme not in ('http', 'https'):
         raise ValueError('bad scheme {}'.format(endpoint.scheme))
     if not isinstance(endpoint.host, str) or not endpoint.host:
-        raise ValueError('bad host {}'.format(endpoint.scheme))
+        raise ValueError('bad host {}'.format(endpoint.host))
 
 DEFAULT_SCHEME = 'http'
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -16,14 +16,14 @@ class TestConnection(unittest.TestCase):
         self.loop = TestLoop()
 
     def test_ctor(self):
-        c = Connection(Endpoint('host', 9999), loop=self.loop)
-        self.assertEqual(Endpoint('host', 9999), c.endpoint)
+        c = Connection(Endpoint('http', 'host', 9999), loop=self.loop)
+        self.assertEqual(Endpoint('http', 'host', 9999), c.endpoint)
 
     def test_bad_status_common(self):
 
         @asyncio.coroutine
         def go():
-            conn = Connection(Endpoint('host', 9999), loop=self.loop)
+            conn = Connection(Endpoint('http', 'host', 9999), loop=self.loop)
             resp = mock.Mock()
             resp.status = 401
             r2 = asyncio.Future(loop=self.loop)
@@ -45,7 +45,7 @@ class TestConnection(unittest.TestCase):
 
         @asyncio.coroutine
         def go():
-            conn = Connection(Endpoint('host', 9999), loop=self.loop)
+            conn = Connection(Endpoint('http', 'host', 9999), loop=self.loop)
             resp = mock.Mock()
             resp.status = 401
             r2 = asyncio.Future(loop=self.loop)
@@ -67,7 +67,7 @@ class TestConnection(unittest.TestCase):
 
         @asyncio.coroutine
         def go():
-            conn = Connection(Endpoint('host', 9999), loop=self.loop)
+            conn = Connection(Endpoint('http', 'host', 9999), loop=self.loop)
             resp = mock.Mock()
             resp.status = 400
             r2 = asyncio.Future(loop=self.loop)
@@ -89,7 +89,7 @@ class TestConnection(unittest.TestCase):
 
         @asyncio.coroutine
         def go():
-            conn = Connection(Endpoint('host', 9999), loop=self.loop)
+            conn = Connection(Endpoint('http', 'host', 9999), loop=self.loop)
             resp = mock.Mock()
             resp.status = 404
             r2 = asyncio.Future(loop=self.loop)
@@ -111,7 +111,7 @@ class TestConnection(unittest.TestCase):
 
         @asyncio.coroutine
         def go():
-            conn = Connection(Endpoint('host', 9999), loop=self.loop)
+            conn = Connection(Endpoint('http', 'host', 9999), loop=self.loop)
             resp = mock.Mock()
             resp.status = 409
             r2 = asyncio.Future(loop=self.loop)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -171,7 +171,8 @@ class TestConnectionPool(unittest.TestCase):
         @asyncio.coroutine
         def go():
             pool = self.make_pool(connections=[])
-            conn = Connection(Endpoint('http', 'localhost', 9200), loop=self.loop)
+            conn = Connection(Endpoint('http', 'localhost', 9200),
+                              loop=self.loop)
 
             yield from pool.mark_live(conn)
             self.assertNotIn(conn, pool._dead_count)
@@ -183,7 +184,8 @@ class TestConnectionPool(unittest.TestCase):
         @asyncio.coroutine
         def go():
             pool = self.make_pool(connections=[])
-            conn = Connection(Endpoint('http', 'localhost', 9200), loop=self.loop)
+            conn = Connection(Endpoint('http', 'localhost', 9200),
+                              loop=self.loop)
             pool._dead_count[conn] = 1
 
             yield from pool.mark_live(conn)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -50,7 +50,7 @@ class TestConnectionPool(unittest.TestCase):
 
     def make_pool(self, connections=default):
         if connections is default:
-            connections = [Connection(Endpoint('localhost', 9200),
+            connections = [Connection(Endpoint('http', 'localhost', 9200),
                                       loop=self.loop)]
         pool = ConnectionPool(connections, loop=self.loop)
         self.addCleanup(pool.close)
@@ -171,7 +171,7 @@ class TestConnectionPool(unittest.TestCase):
         @asyncio.coroutine
         def go():
             pool = self.make_pool(connections=[])
-            conn = Connection(Endpoint('localhost', 9200), loop=self.loop)
+            conn = Connection(Endpoint('http', 'localhost', 9200), loop=self.loop)
 
             yield from pool.mark_live(conn)
             self.assertNotIn(conn, pool._dead_count)
@@ -183,7 +183,7 @@ class TestConnectionPool(unittest.TestCase):
         @asyncio.coroutine
         def go():
             pool = self.make_pool(connections=[])
-            conn = Connection(Endpoint('localhost', 9200), loop=self.loop)
+            conn = Connection(Endpoint('http', 'localhost', 9200), loop=self.loop)
             pool._dead_count[conn] = 1
 
             yield from pool.mark_live(conn)
@@ -195,8 +195,8 @@ class TestConnectionPool(unittest.TestCase):
 
         @asyncio.coroutine
         def go():
-            c1 = Connection(Endpoint('h1', 1), loop=self.loop)
-            c2 = Connection(Endpoint('h2', 2), loop=self.loop)
+            c1 = Connection(Endpoint('http', 'h1', 1), loop=self.loop)
+            c2 = Connection(Endpoint('http', 'h2', 2), loop=self.loop)
             pool = self.make_pool(connections=[c1, c2])
 
             yield from pool.mark_dead(c1)
@@ -213,8 +213,8 @@ class TestConnectionPool(unittest.TestCase):
 
         @asyncio.coroutine
         def go():
-            c1 = Connection(Endpoint('h1', 1), loop=self.loop)
-            c2 = Connection(Endpoint('h2', 2), loop=self.loop)
+            c1 = Connection(Endpoint('http', 'h1', 1), loop=self.loop)
+            c2 = Connection(Endpoint('http', 'h2', 2), loop=self.loop)
             pool = self.make_pool(connections=[c1, c2])
 
             yield from pool.mark_dead(c1)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 import unittest
-
+import urllib.parse
 
 from aioes.transport import Endpoint, Transport
 
@@ -121,11 +121,14 @@ class TestTransport(unittest.TestCase):
         tr = self.make_transport(endpoints=['https://john:doe@localhost:9200'])
         self.assertEqual([Endpoint('https', 'john:doe@localhost', 9200)],
                          tr.endpoints)
+        self.assertEqual(
+            ('https', 'john:doe@localhost:9200', '/', '', '', ''),
+            tuple(urllib.parse.urlparse(tr._pool.connections[0]._base_url))
+        )
 
-    def test_username_password_endpoints_without_port_https(self):
-        tr = self.make_transport(endpoints=['https://john:doe@localhost'])
-        self.assertEqual([Endpoint('https', 'john:doe@localhost', 9200)],
-                         tr.endpoints)
+    def test_bad_schema(self):
+        with self.assertRaises(RuntimeError):
+            self.make_transport(endpoints=['s3://john:doe@localhost:9200'])
 
     def test_sniff(self):
         tr = self.make_transport(sniffer_interval=0.001)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -130,6 +130,16 @@ class TestTransport(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.make_transport(endpoints=['s3://john:doe@localhost:9200'])
 
+    def test_default_port_https(self):
+        tr = self.make_transport(endpoints=['https://localhost'])
+        self.assertEqual([Endpoint('https', 'localhost', 443)],
+                         tr.endpoints)
+
+    def test_default_port_http(self):
+        tr = self.make_transport(endpoints=['http://localhost'])
+        self.assertEqual([Endpoint('http', 'localhost', 9200)],
+                         tr.endpoints)
+
     def test_sniff(self):
         tr = self.make_transport(sniffer_interval=0.001)
 


### PR DESCRIPTION
- Endpoint namedtuple changes:
  - gains a new item netloc a position 0
  - Username and password are stored in host item 1
- Use urllib to parse connection strings