### PR TITLE
Added MANIFEST.in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ htmlcov
 docs/_build
 dist
 cover
+.idea

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE.txt
+include CHANGES.txt
+include README.rst
+graft aioes
+global-exclude *.pyc *.swp


### PR DESCRIPTION
Hi,

I've just noticed that there are missing ``MANIFEST.in`` in the ``aioes``. Because of this, installing from sdist doesn't work.

```
(p35test) 5:~ anti1869$ pip install aioes --no-use-wheel
Collecting aioes
  Downloading aioes-0.4.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/private/var/folders/7b/vdjngpnj00d17rlkbm07h0p00000gn/T/pip-build-g9co0143/aioes/setup.py", line 50, in <module>
        long_description='\n\n'.join((read('README.rst'), read('CHANGES.txt'))),
      File "/private/var/folders/7b/vdjngpnj00d17rlkbm07h0p00000gn/T/pip-build-g9co0143/aioes/setup.py", line 18, in read
        return open(os.path.join(os.path.dirname(__file__), f)).read().strip()
    FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/7b/vdjngpnj00d17rlkbm07h0p00000gn/T/pip-build-g9co0143/aioes/CHANGES.txt'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/7b/vdjngpnj00d17rlkbm07h0p00000gn/T/pip-build-g9co0143/aioes
You are using pip version 7.1.2, however version 8.1.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

I've quickly fixed this by copying ``MANIFEST.in`` from your other ``aio-libs`` project. 