### PR TITLE
Create Index fails when integrated with Elasticsearch 5.0

### DIFF
--- a/aioes/connection.py
+++ b/aioes/connection.py
@@ -24,7 +24,7 @@ class Connection:
                 loop=loop,
                 verify_ssl=verify_ssl),
             loop=loop)
-        self._base_url = '{0.scheme}://{0.host}:{0.port}/'.format(endpoint)
+        self._base_url = '{0.scheme}://{0.host}:{0.port}'.format(endpoint)
 
     @property
     def endpoint(self):


### PR DESCRIPTION
Removed extra / in base url
Url generated was baseurl//myindex/testtype/. With Elasticsearch 5.0 create index request throws java.lang.StringIndexOutOfBoundsException: String index out of range: 0 - params: {index=,op_type=create, id=testtype, type=myindex}