### PR TITLE
elastic 5.0 can't find //index urls and the base path has already a /

### DIFF
--- a/aioes/client/utils.py
+++ b/aioes/client/utils.py
@@ -41,7 +41,7 @@ def _make_path(*parts):
     """
     # TODO: maybe only allow some parts to be lists/tuples ?
     # preserve ',' and '*' in url for nicer URLs in logs
-    return '/' + '/'.join(
+    return '/'.join(
         quote_plus(_escape(p), b',*')
         for p in parts if p not in SKIP_IN_PATH)
 


### PR DESCRIPTION
On elasticsearch the urls //index don't work so it returns error. As the base_path has already a tailing / its better to not add on the make_path util function.