### PR TITLE
Fixing url handling

### DIFF
--- a/aioes/connection.py
+++ b/aioes/connection.py
@@ -35,7 +35,7 @@ class Connection:
 
     @asyncio.coroutine
     def perform_request(self, method, url, params, body):
-        url = self._base_url + url
+        url = self._base_url + url.lstrip()
         resp = yield from self._session.request(
             method, url, params=params, data=body)
         resp_body = yield from resp.text()


### PR DESCRIPTION
When you try to execute a call like: es.search(index='my_index', doc_type='my_type') it raises an exception:
RequestError: TransportError(400, 'No handler found for uri [//items_types/products/_search] and method [GET]')

With this fix the query works