### PR TITLE
Update tests to run with multiple elasticsearch versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ matrix:
   - python: "3.6"
     env: TASKS="cmp"
   - python: "3.6"
-    env: TASKS="cov" TEST_ARGS="-rsxX -v --es_tag=5.2"
+    env: TASKS="cov" TEST_ARGS="-rsxX -v --es-tag=2.4 --es-tag=5.2"
   allow_failures:
-  - env: TASKS="cov" TEST_ARGS="-rsxX -v --es_tag=5.2"
+  - env: TASKS="cov" TEST_ARGS="-rsxX -v --es-tag=2.4 --es-tag=5.2"
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_cache:
 
 env:
   global:
-  - TASKS="cov setup-check" TEST_ARGS="-rsxX -v"
+  - TASKS="cov setup-check" TEST_ARGS="-rsxX -v --es-tag=1.7 --es-tag=2.4 --es-tag=5.2"
   matrix:
   - PYTHONASYNCIODEBUG=1
   - PYTHONASYNCIODEBUG=
@@ -39,10 +39,6 @@ matrix:
   include:
   - python: "3.6"
     env: TASKS="cmp"
-  - python: "3.6"
-    env: TASKS="cov" TEST_ARGS="-rsxX -v --es-tag=1.7 --es-tag=2.4 --es-tag=5.2"
-  allow_failures:
-  - env: TASKS="cov" TEST_ARGS="-rsxX -v --es-tag=1.7 --es-tag=2.4 --es-tag=5.2"
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ matrix:
   - python: "3.6"
     env: TASKS="cmp"
   - python: "3.6"
-    env: TASKS="cov" TEST_ARGS="-rsxX -v --es-tag=2.4 --es-tag=5.2"
+    env: TASKS="cov" TEST_ARGS="-rsxX -v --es-tag=1.7 --es-tag=2.4 --es-tag=5.2"
   allow_failures:
-  - env: TASKS="cov" TEST_ARGS="-rsxX -v --es-tag=2.4 --es-tag=5.2"
+  - env: TASKS="cov" TEST_ARGS="-rsxX -v --es-tag=1.7 --es-tag=2.4 --es-tag=5.2"
 
 deploy:
   provider: pypi

--- a/aioes/client/__init__.py
+++ b/aioes/client/__init__.py
@@ -380,7 +380,7 @@ class Elasticsearch:
              _source=default, _source_exclude=default,
              _source_include=default, fields=default, parent=default,
              preference=default, realtime=default, refresh=default,
-             routing=default):
+             routing=default, stored_fields=default):
         """
         Get multiple documents based on an index, type (optional) and ids.
         """
@@ -403,6 +403,8 @@ class Elasticsearch:
             params['refresh'] = bool(refresh)
         if routing is not default:
             params['routing'] = routing
+        if stored_fields is not default:
+            params['stored_fields'] = stored_fields
 
         _, data = yield from self.transport.perform_request(
             'GET',
@@ -426,7 +428,8 @@ class Elasticsearch:
                sort=default, source=default, stats=default,
                suggest_field=default, suggest_mode=default,
                suggest_size=default, suggest_text=default,
-               timeout=default, version=default):
+               timeout=default, version=default,
+               stored_fields=default):
         """
         Execute a search query and get back search hits that match the query.
         """
@@ -489,6 +492,8 @@ class Elasticsearch:
             params['version'] = int(version)
         if analyzer is not default:
             params['analyzer'] = analyzer
+        if stored_fields is not default:
+            params['stored_fields'] = stored_fields
 
         if expand_wildcards is not default:
             if not isinstance(expand_wildcards, str):
@@ -642,7 +647,7 @@ class Elasticsearch:
                 df=default, fields=default, lenient=default,
                 lowercase_expanded_terms=default, parent=default,
                 preference=default, q=default, routing=default,
-                source=default):
+                source=default, stored_fields=default):
         """
         The explain api computes a score explanation for a query and a
         specific document. This can give useful feedback whether a document
@@ -677,6 +682,8 @@ class Elasticsearch:
             params['routing'] = routing
         if source is not default:
             params['source'] = source
+        if stored_fields is not default:
+            params['stored_fields'] = stored_fields
         if default_operator is not default:
             if not isinstance(default_operator, str):
                 raise TypeError("'default_operator' parameter is not a string")

--- a/aioes/client/__init__.py
+++ b/aioes/client/__init__.py
@@ -839,7 +839,7 @@ class Elasticsearch:
                 raise ValueError("'consistency' parameter should be one of "
                                  "'one', 'quorum', 'all'")
         if refresh is not default:
-            params['refresh'] = bool(refresh)
+            params['refresh'] = str(bool(refresh)).lower()
         if routing is not default:
             params['routing'] = routing
         if replication is not default:

--- a/aioes/client/__init__.py
+++ b/aioes/client/__init__.py
@@ -130,7 +130,9 @@ class Elasticsearch:
         if percolate is not default:
             params['percolate'] = percolate
         if refresh is not default:
-            params['refresh'] = bool(refresh)
+            if refresh != 'wait_for':
+                refresh = str(bool(refresh)).lower()
+            params['refresh'] = refresh
         if replication is not default:
             if not isinstance(replication, str):
                 raise TypeError("'replication' parameter is not a string")
@@ -275,7 +277,9 @@ class Elasticsearch:
         if realtime is not default:
             params['realtime'] = bool(realtime)
         if refresh is not default:
-            params['refresh'] = bool(refresh)
+            if refresh != 'wait_for':
+                refresh = str(bool(refresh)).lower()
+            params['refresh'] = refresh
         if routing is not default:
             params['routing'] = routing
         if version is not default:
@@ -326,7 +330,9 @@ class Elasticsearch:
         if parent is not default:
             params['parent'] = parent
         if refresh is not default:
-            params['refresh'] = bool(refresh)
+            if refresh != 'wait_for':
+                refresh = str(bool(refresh)).lower()
+            params['refresh'] = refresh
         if replication is not default:
             if not isinstance(replication, str):
                 raise TypeError("'replication' parameter is not a string")
@@ -747,7 +753,9 @@ class Elasticsearch:
         if parent is not default:
             params['parent'] = parent
         if refresh is not default:
-            params['refresh'] = bool(refresh)
+            if refresh != 'wait_for':
+                refresh = str(bool(refresh)).lower()
+            params['refresh'] = refresh
         if routing is not default:
             params['routing'] = routing
         if version is not default:

--- a/aioes/client/cluster.py
+++ b/aioes/client/cluster.py
@@ -12,7 +12,9 @@ class ClusterClient(NamespacedClient):
     def health(self, index=None, *,
                level=default, local=default, master_timeout=default,
                timeout=default, wait_for_active_shards=default,
-               wait_for_nodes=default, wait_for_relocating_shards=default,
+               wait_for_nodes=default,
+               wait_for_relocating_shards=default,
+               wait_for_no_relocating_shards=default,
                wait_for_status=default):
         """
         Get a very simple status on the health of the cluster.
@@ -56,8 +58,19 @@ class ClusterClient(NamespacedClient):
         if wait_for_nodes is not default:
             params['wait_for_nodes'] = str(wait_for_nodes)
         if wait_for_relocating_shards is not default:
+            if wait_for_no_relocating_shards is not default:
+                raise ValueError("Either wait_for_relocating_shards or"
+                                 " wait_for_no_relocating_shards must be set,"
+                                 " not both")
             params['wait_for_relocating_shards'] = \
                 int(wait_for_relocating_shards)
+        if wait_for_no_relocating_shards is not default:
+            if wait_for_relocating_shards is not default:
+                raise ValueError("Either wait_for_relocating_shards or"
+                                 " wait_for_no_relocating_shards must be set,"
+                                 " not both")
+            params['wait_for_no_relocating_shards'] = \
+                int(wait_for_no_relocating_shards)
         if wait_for_status is not default:
             if not isinstance(wait_for_status, str):
                 raise TypeError("'wait_for_status' parameter is not a string")

--- a/aioes/client/indices.py
+++ b/aioes/client/indices.py
@@ -985,7 +985,7 @@ class IndicesClient(NamespacedClient):
                                  "'segments', 'store', 'warmer'")
 
         _, data = yield from self.transport.perform_request(
-            'GET', _make_path(index, '_stats', metric),
+            'GET', _make_path(index, '_stats'),
             params=params)
         return data
 
@@ -1059,6 +1059,38 @@ class IndicesClient(NamespacedClient):
 
         _, data = yield from self.transport.perform_request(
             'POST', _make_path(index, '_optimize'), params=params)
+        return data
+
+    @asyncio.coroutine
+    def force_merge(self, index=None, *,
+                    flush=default, allow_no_indices=default,
+                    expand_wildcards=default,
+                    ignore_unavailable=default,
+                    max_num_segments=default,
+                    only_expunge_deletes=default):
+        """Force merging one or more indices through an API."""
+        params = {}
+        if flush is not default:
+            params['flush'] = bool(flush)
+        if max_num_segments is not default:
+            params['max_num_segments'] = int(max_num_segments)
+        if only_expunge_deletes is not default:
+            params['only_expunge_deletes'] = bool(only_expunge_deletes)
+        if allow_no_indices is not default:
+            params['allow_no_indices'] = bool(allow_no_indices)
+        if expand_wildcards is not default:
+            if not isinstance(expand_wildcards, str):
+                raise TypeError("'expand_wildcards' parameter is not a string")
+            elif expand_wildcards.lower() in ('open', 'closed'):
+                params['expand_wildcards'] = expand_wildcards.lower()
+            else:
+                raise ValueError("'expand_wildcards' parameter should be one"
+                                 " of 'open', 'closed'")
+        if ignore_unavailable is not default:
+            params['ignore_unavailable'] = bool(ignore_unavailable)
+
+        _, data = yield from self.transport.perform_request(
+            'POST', _make_path(index, '_forcemerge'), params=params)
         return data
 
     @asyncio.coroutine

--- a/aioes/client/indices.py
+++ b/aioes/client/indices.py
@@ -13,7 +13,9 @@ class IndicesClient(NamespacedClient):
     def analyze(self, index=None, body=None, *,
                 analyzer=default, char_filters=default, field=default,
                 filters=default, prefer_local=default, text=default,
-                tokenizer=default, token_filters=default):
+                tokenizer=default, token_filters=default,
+                # Es 5.x params
+                filter=default, token_filter=default, char_filter=default):
         """Run analyze tool.
 
         Perform the analysis process on a text and return the tokens
@@ -21,6 +23,13 @@ class IndicesClient(NamespacedClient):
 
         """
         params = {}
+        duplicate_err = "Either {0}s or {0} must be set, not both".format
+        if filters is not default and filter is not default:
+            raise ValueError(duplicate_err('filter'))
+        if char_filters is not default and char_filter is not default:
+            raise ValueError(duplicate_err('char_filter'))
+        if token_filters is not default and token_filter is not default:
+            raise ValueError(duplicate_err('token_filter'))
         if analyzer is not default:
             params['analyzer'] = analyzer
         if char_filters is not default:
@@ -37,6 +46,12 @@ class IndicesClient(NamespacedClient):
             params['tokenizer'] = tokenizer
         if token_filters is not default:
             params['token_filters'] = token_filters
+        if filter is not default:
+            params['filter'] = filter
+        if char_filter is not default:
+            params['char_filter'] = char_filter
+        if token_filter is not default:
+            params['token_filter'] = token_filter
 
         _, data = yield from self.transport.perform_request(
             'GET',

--- a/aioes/client/nodes.py
+++ b/aioes/client/nodes.py
@@ -121,7 +121,8 @@ class NodesClient(NamespacedClient):
 
     @asyncio.coroutine
     def hot_threads(self, node_id=None, *, type_=default, interval=default,
-                    snapshots=default, threads=default):
+                    snapshots=default, threads=default,
+                    ignore_idle_threads=default):
         """
         An API allowing to get the current hot threads on each node
         in the cluster.
@@ -148,6 +149,8 @@ class NodesClient(NamespacedClient):
             params['snapshots'] = snapshots
         if threads is not default:
             params['threads'] = threads
+        if ignore_idle_threads is not default:
+            params['ignore_idle_threads'] = str(ignore_idle_threads).lower()
 
         _, data = yield from self.transport.perform_request(
             'GET', _make_path('_nodes', node_id, 'hot_threads'),

--- a/aioes/pool.py
+++ b/aioes/pool.py
@@ -15,9 +15,14 @@ class AbstractSelector(metaclass=abc.ABCMeta):
 
 
 class RandomSelector(AbstractSelector):
+    random = random
+
+    def __init__(self, seed=None):
+        if seed is not None:
+            self.random = random.Random(seed)
 
     def select(self, connections):
-        return random.choice(connections)
+        return self.random.choice(connections)
 
 
 class RoundRobinSelector(AbstractSelector):

--- a/aioes/transport.py
+++ b/aioes/transport.py
@@ -188,7 +188,7 @@ class Transport:
                     _, headers, node_info = yield from asyncio.wait_for(
                         c.perform_request(
                             'GET',
-                            '/_nodes/_all/clear',
+                            '/_nodes/_all/http',
                             None,
                             None),
                         timeout=self._sniffer_timeout,
@@ -208,9 +208,13 @@ class Transport:
             raise
 
         endpoints = []
-        address = 'http_address'
         for n in node_info['nodes'].values():
-            match = self.ADDRESS_RE.search(n.get(address, ''))
+            # try several fields
+            http_addr_1 = n.get('http_address', '')
+            http_addr_2 = n.get('http', {}).get('publish_address', '')
+            match = self.ADDRESS_RE.search(http_addr_1)
+            if not match:
+                match = self.ADDRESS_RE.search(http_addr_2)
             if not match:
                 continue
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,11 +60,11 @@ def pytest_collection_modifyitems(session, config, items):
             if min_tag and max_tag:
                 if not (min_tag <= cur < max_tag):
                     item.add_marker(pytest.mark.skip(reason=reason))
-            if min_tag:
+            elif min_tag:
                 if cur < min_tag:
                     item.add_marker(pytest.mark.skip(reason=reason))
-            if max_tag:
-                if cur > max_tag:
+            elif max_tag:
+                if cur >= max_tag:
                     item.add_marker(pytest.mark.skip(reason=reason))
 
 

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -142,13 +142,15 @@ def test_pending_tasks(client):
 
 
 @asyncio.coroutine
-def test_thread_pool(client):
+def test_thread_pool(client, es_tag):
     ret = yield from client.cat.thread_pool(v=True)
     header = next(map(lambda s: s.split(' '), ret.splitlines()), None)
     assert header is not None
-    # XXX: works for es-2.4
-    assert 'host' in header
-    assert 'ip' in header
+    if es_tag < (5, 0):
+        assert 'host' in header
+        assert 'ip' in header
+    else:
+        assert 'node_name' in header
 
 
 @asyncio.coroutine

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -3,22 +3,7 @@ import asyncio
 import pytest
 
 
-from aioes import Elasticsearch
-from aioes.exception import NotFoundError
-
-
 INDEX = 'test_elasticsearch'
-
-
-@pytest.fixture
-def client(es_params, loop):
-    client = Elasticsearch([{'host': es_params['host']}], loop=loop)
-    try:
-        loop.run_until_complete(client.delete(INDEX, '', ''))
-    except NotFoundError:
-        pass
-    yield client
-    client.close()
 
 
 @asyncio.coroutine

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -461,6 +461,7 @@ def test_search(client, es_tag):
                                  expand_wildcards='1')
 
 
+@pytest.mark.es_tag(min=(2, 0), reason='fails on 1.7, bad test')
 @asyncio.coroutine
 def test_count(client):
     """ count """

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -2,24 +2,8 @@ import asyncio
 
 import pytest
 
-from aioes import Elasticsearch
-from aioes.exception import NotFoundError
-
 
 INDEX = 'test_elasticsearch'
-
-
-@pytest.fixture
-def client(es_params, loop):
-    client = Elasticsearch([
-        {'host': es_params['host'], 'port': es_params['port']}],
-        loop=loop)
-    try:
-        loop.run_until_complete(client.delete(INDEX, '', ''))
-    except NotFoundError:
-        pass
-    yield client
-    client.close()
 
 
 @asyncio.coroutine

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -23,9 +23,13 @@ def client(es_params, loop):
 
 
 @asyncio.coroutine
-def test_health(client):
+def test_health(client, es_tag):
     data = yield from client.cluster.health()
     assert 'status' in data
+    if es_tag >= (5, 0):
+        kwargs = dict(wait_for_no_relocating_shards=0)
+    else:
+        kwargs = dict(wait_for_relocating_shards=0)
     data = yield from client.cluster.health(
         level='indices',
         local=True,
@@ -33,7 +37,7 @@ def test_health(client):
         timeout='1s',
         # wait_for_active_shards=1, # XXX: verify there are some shards
         # wait_for_nodes='>2',  # XXX: must verify nodes count
-        wait_for_relocating_shards=0)
+        **kwargs)
     assert 'status' in data
 
 

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -74,14 +74,21 @@ def test_create_errors(client, kwargs):
 
 
 @asyncio.coroutine
-def test_refresh(client):
+def test_refresh(client, es_tag):
     yield from client.index(INDEX, 'type', MESSAGE, '1')
     data = yield from client.indices.refresh(INDEX)
     assert '_shards' in data
-    yield from client.indices.refresh(
-        INDEX,
-        allow_no_indices=False, expand_wildcards='closed',
-        ignore_unavailable=True, ignore_indices='', force=True)
+
+    if es_tag > (5, 0):
+        kwargs = dict()
+    else:
+        kwargs = dict(force=True,
+                      ignore_indices='')
+    yield from client.indices.refresh(INDEX,
+                                      allow_no_indices=False,
+                                      expand_wildcards='closed',
+                                      ignore_unavailable=True,
+                                      **kwargs)
     with pytest.raises(TypeError):
         yield from client.indices.refresh(
             INDEX, expand_wildcards=1)
@@ -91,14 +98,22 @@ def test_refresh(client):
 
 
 @asyncio.coroutine
-def test_flush(client):
+def test_flush(client, es_tag):
     yield from client.index(INDEX, 'type', MESSAGE, '1')
     data = yield from client.indices.flush(INDEX)
     assert '_shards' in data
-    yield from client.indices.flush(
-        INDEX, full=True,
-        allow_no_indices=False, expand_wildcards='closed',
-        ignore_unavailable=True, ignore_indices='', force=True)
+
+    if es_tag > (5, 0):
+        kwargs = dict()
+    else:
+        kwargs = dict(full=True,
+                      ignore_indices='')
+    yield from client.indices.flush(INDEX,
+                                    allow_no_indices=False,
+                                    expand_wildcards='closed',
+                                    ignore_unavailable=True,
+                                    force=True,
+                                    **kwargs)
     with pytest.raises(TypeError):
         yield from client.indices.flush(
             INDEX, expand_wildcards=1)
@@ -207,17 +222,22 @@ def test_exists_type(client):
 
 
 @asyncio.coroutine
-def test_get_settings(client):
+def test_get_settings(client, es_tag):
     yield from client.index(INDEX, 'type', MESSAGE, '1')
     yield from client.indices.refresh(INDEX)
     data = yield from client.indices.get_settings()
     assert INDEX in data
+
+    if es_tag > (5, 0):
+        kwargs = dict()
+    else:
+        kwargs = dict(ignore_indices='')
     data = yield from client.indices.get_settings(
         expand_wildcards='open',
-        ignore_indices='',
         flat_settings=False,
         ignore_unavailable=False,
-        local=True)
+        local=True,
+        **kwargs)
     assert INDEX in data
     with pytest.raises(TypeError):
         yield from client.indices.get_settings(expand_wildcards=1)
@@ -271,23 +291,28 @@ def test_status(client):
 
 
 @asyncio.coroutine
-def test_stats(client):
+def test_stats(client, es_tag):
     data = yield from client.indices.stats()
     assert 'indices' in data
+
+    if es_tag > (5, 0):
+        kwargs = dict()
+    else:
+        kwargs = dict(ignore_indices=False,
+                      docs=1)
     data = yield from client.indices.stats(
         metric='_all',
         completion_fields='*',
-        docs=1,
         fielddata_fields='*',
         fields='*',
         groups='*',
         allow_no_indices=True,
         expand_wildcards='open',
-        ignore_indices=False,
         ignore_unavailable=True,
         level='cluster',
         types='*',
-        human=True)
+        human=True,
+        **kwargs)
     assert '_all' in data
     with pytest.raises(TypeError):
         yield from client.indices.stats(expand_wildcards=1)
@@ -304,16 +329,21 @@ def test_stats(client):
 
 
 @asyncio.coroutine
-def test_segments(client):
+def test_segments(client, es_tag):
     data = yield from client.indices.segments()
     assert 'indices' in data
     assert '_shards' in data
+
+    if es_tag > (5, 0):
+        kwargs = dict()
+    else:
+        kwargs = dict(ignore_indices=True)
     data = yield from client.indices.segments(
         allow_no_indices=True,
-        ignore_indices=True,
         ignore_unavailable=True,
         expand_wildcards='open',
-        human=True)
+        human=True,
+        **kwargs)
     assert 'indices' in data
     assert '_shards' in data
     with pytest.raises(TypeError):
@@ -322,6 +352,7 @@ def test_segments(client):
         yield from client.indices.segments(expand_wildcards='1')
 
 
+@pytest.mark.es_tag(max=(5, 0))
 @asyncio.coroutine
 def test_optimize(client):
     data = yield from client.indices.optimize()
@@ -344,20 +375,46 @@ def test_optimize(client):
         yield from client.indices.optimize(expand_wildcards='1')
 
 
+@pytest.mark.es_tag(min=(5, 0))
 @asyncio.coroutine
-def test_validate_query(client):
+def test_forcemerge(client):
+    data = yield from client.indices.force_merge()
+    assert '_shards' in data
+    data = yield from client.indices.force_merge(
+        allow_no_indices=True,
+        expand_wildcards='open',
+        ignore_unavailable=True,
+        max_num_segments=0,
+        only_expunge_deletes=True,
+        flush=True)
+    assert '_shards' in data
+    with pytest.raises(TypeError):
+        yield from client.indices.optimize(expand_wildcards=1)
+    with pytest.raises(ValueError):
+        yield from client.indices.optimize(expand_wildcards='1')
+
+
+@asyncio.coroutine
+def test_validate_query(client, es_tag):
     yield from client.indices.create(INDEX)
     data = yield from client.indices.validate_query()
     assert '_shards' in data
+
+    if es_tag > (5, 0):
+        kwargs = dict()
+    else:
+        kwargs = dict(ignore_indices=True,
+                      operation_threading='',
+                      )
+
     yield from client.indices.validate_query(
         explain=True,
         allow_no_indices=True,
         q='',
-        ignore_indices=True,
         source='',
-        operation_threading='',
         expand_wildcards='open',
-        ignore_unavailable=False)
+        ignore_unavailable=False,
+        **kwargs)
     with pytest.raises(TypeError):
         yield from client.indices.validate_query(expand_wildcards=1)
     with pytest.raises(ValueError):
@@ -365,24 +422,29 @@ def test_validate_query(client):
 
 
 @asyncio.coroutine
-def test_clear_cache(client):
+def test_clear_cache(client, es_tag):
     yield from client.indices.create(INDEX)
     data = yield from client.indices.clear_cache()
     assert '_shards' in data
+    if es_tag > (5, 0):
+        kwargs = dict()
+    else:
+        kwargs = dict(id=False,
+                      id_cache=True,
+                      ignore_indices=False,
+                      filter_keys='',
+                      )
     yield from client.indices.clear_cache(
         field_data=True,
         fielddata=True,
         recycler=True,
-        id_cache=True,
-        filter_keys='',
         filter_cache=True,
         filter=False,
         fields='',
-        id=False,
         allow_no_indices=False,
-        ignore_indices=False,
         ignore_unavailable=True,
-        expand_wildcards='open')
+        expand_wildcards='open',
+        **kwargs)
     assert '_shards' in data
     with pytest.raises(TypeError):
         yield from client.indices.clear_cache(expand_wildcards=1)

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -430,7 +430,7 @@ def test_mapping(client, es_tag):
 
     # DELETE
     # NOTE: it is not possible to delete mapping since 2.0
-    if tuple(map(int, es_tag.split('.'))) < (2, 0):
+    if es_tag < (2, 0):
         yield from client.indices.delete_mapping(INDEX, DOCTYPE)
         data = yield from client.indices.get_mapping(INDEX, DOCTYPE)
         assert not data

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,19 +1,17 @@
 import asyncio
 import pytest
 from aioes import Elasticsearch
-from aioes.exception import NotFoundError
+from aioes.exception import NotFoundError, RequestError
+
+
+INDEX = 'test_elasticsearch'
 
 
 @pytest.fixture
-def index():
-    return 'test_elasticsearch'
-
-
-@pytest.fixture
-def client(es_params, index, loop):
+def client(es_params, loop):     # XXX: to much clients all over tests;
     client = Elasticsearch([{'host': es_params['host']}], loop=loop)
     try:
-        loop.run_until_complete(client.delete(index, '', ''))
+        loop.run_until_complete(client.delete(INDEX, '', ''))
     except NotFoundError:
         pass
     yield client
@@ -33,7 +31,33 @@ def test_stats(client):
     assert len(ret['nodes']) > 0
 
 
+@pytest.mark.parametrize('kwargs', [
+    dict(),
+    dict(threads=3),
+    dict(type_='cpu'),
+    dict(type_='wait'),
+    dict(ignore_idle_threads=False),
+    dict(ignore_idle_threads='yes'),  # NOTE: value is ignored by elastic
+    dict(ignore_idle_threads='ok'),
+], ids=repr)
 @asyncio.coroutine
-def test_hot_threads(client):
-    ret = yield from client.nodes.hot_threads()
-    assert 'cpu usage by thread' in ret
+def test_hot_threads(client, kwargs):
+    ret = yield from client.nodes.hot_threads(**kwargs)
+    lines = ret.split("\n\n")
+    assert len(lines) >= 2  # Header + empty line
+    # It is probable that no data is returned (in es 5.x)
+    if lines[1]:
+        assert 'cpu usage by thread' in lines[1]
+
+
+@pytest.mark.parametrize('kwargs', [
+    pytest.mark.xfail(
+        dict(type_='foobar'),
+        reason="empty result is returned"),
+    dict(threads='abc'),
+    dict(interval='minute'),
+], ids=repr)
+@asyncio.coroutine
+def test_hot_threads__errors(client, kwargs):
+    with pytest.raises(RequestError):
+        assert (yield from client.nodes.hot_threads(**kwargs)) is None

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,21 +1,9 @@
 import asyncio
 import pytest
-from aioes import Elasticsearch
-from aioes.exception import NotFoundError, RequestError
+from aioes.exception import RequestError
 
 
 INDEX = 'test_elasticsearch'
-
-
-@pytest.fixture
-def client(es_params, loop):     # XXX: to much clients all over tests;
-    client = Elasticsearch([{'host': es_params['host']}], loop=loop)
-    try:
-        loop.run_until_complete(client.delete(INDEX, '', ''))
-    except NotFoundError:
-        pass
-    yield client
-    client.close()
 
 
 @asyncio.coroutine

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -9,16 +9,14 @@ from aioes import Elasticsearch
 from aioes.exception import NotFoundError
 
 
-@pytest.fixture
-def index():
-    return 'test_elasticsearch'
+INDEX = 'test_elasticsearch'
 
 
 @pytest.fixture
-def client(es_params, index, loop, repo_name, snapshot_name):
+def client(es_params, loop, repo_name, snapshot_name):
     client = Elasticsearch([{'host': es_params['host']}], loop=loop)
     try:
-        loop.run_until_complete(client.delete(index, '', ''))
+        loop.run_until_complete(client.delete(INDEX, '', ''))
     except NotFoundError:
         pass
     yield client
@@ -98,10 +96,10 @@ def test_repository(client, repo_path, repo_name):
 
 @pytest.mark.xfail(reason="Elasticsearch setting repo.path must be configured")
 @asyncio.coroutine
-def test_snapshot(client, repo_name, repo_path, snapshot_name, index):
+def test_snapshot(client, repo_name, repo_path, snapshot_name):
     # creating index
     yield from client.create(
-        index, 'tweet',
+        INDEX, 'tweet',
         {
             'user': 'Bob',
         },
@@ -133,9 +131,9 @@ def test_snapshot(client, repo_name, repo_path, snapshot_name, index):
 
     # restoring snapshot
     restore_body = {
-        "indices": index,
+        "indices": INDEX,
     }
-    yield from client.indices.close(index)
+    yield from client.indices.close(INDEX)
     ret = yield from client.snapshot.restore(
         repo_name, snapshot_name,
         body=restore_body


### PR DESCRIPTION
* [x] Enabled tags: 1.7, 2.4, 5.2.
* [x] Fixed most 5.x compatibility issues;
* [x] Add `stored_fields` in `mget`, `search`, `explain`;
* [x] Add `wait_for_no_relocating_shards` parameter in `health`;
* [x] Add `filter`, `token_filter`, `char_filter` params in `analyze`;
* [x] Add `force_merge` (renamed `optimize`);
* [x] Add `ignore_idle_threads` param in `hot_threads`;
* [x] Some small fixes;