### PR TITLE
Connection allows inject an external TCP connector

### DIFF
--- a/aioes/connection.py
+++ b/aioes/connection.py
@@ -17,11 +17,11 @@ class Connection:
     Also responsible for logging.
     """
 
-    def __init__(self, endpoint, *, loop, verify_ssl=True):
+    def __init__(self, endpoint, *, loop, verify_ssl=True, connector=None):
         self._endpoint = endpoint
         self._session = aiohttp.ClientSession(
             # limit number of connections?
-            connector=aiohttp.TCPConnector(
+            connector=connector or aiohttp.TCPConnector(
                 use_dns_cache=True,
                 loop=loop,
                 verify_ssl=verify_ssl),

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,3 +1,4 @@
+import aiohttp
 import asyncio
 from unittest import mock
 
@@ -13,6 +14,16 @@ from aioes.transport import Endpoint
 def test_ctor(loop):
     c = Connection(Endpoint('http', 'host', 9999), loop=loop)
     assert Endpoint('http', 'host', 9999) == c.endpoint
+
+
+def test_use_connector_param(loop):
+    connector = aiohttp.TCPConnector(loop=loop)
+    c = Connection(
+        Endpoint('http', 'host', 9999),
+        loop=loop,
+        connector=connector
+    )
+    assert c._session.connector is connector
 
 
 @asyncio.coroutine


### PR DESCRIPTION
Self-explanatory, default connector instantiated by the `Connection` class can't be enough in some occasions. In these situations, the user can since now through this commit gives his own connection instance.